### PR TITLE
feat: Add Google Tag Manager integration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,32 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${dmSans.variable} font-sans antialiased`}>{children}</body>
+      <head>
+        {/* Google Tag Manager */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5K6Z3Z7');`,
+          }}
+        />
+        {/* End Google Tag Manager */}
+      </head>
+      <body className={`${dmSans.variable} font-sans antialiased`}>
+        {/* Google Tag Manager (noscript) */}
+        <noscript>
+          <iframe
+            src="https://www.googletagmanager.com/ns.html?id=GTM-5K6Z3Z7"
+            height="0"
+            width="0"
+            style={{ display: 'none', visibility: 'hidden' }}
+          />
+        </noscript>
+        {/* End Google Tag Manager (noscript) */}
+        {children}
+      </body>
     </html>
   )
 }


### PR DESCRIPTION
## Summary
- Add GTM script to head section with container ID GTM-5K6Z3Z7
- Add GTM noscript fallback for users with JavaScript disabled
- Implement using Next.js best practices with dangerouslySetInnerHTML

Closes #4

## Test plan
- [ ] Verify GTM script loads correctly in browser dev tools
- [ ] Check that GTM container ID GTM-5K6Z3Z7 is active
- [ ] Test noscript fallback functionality
- [ ] Confirm no console errors or warnings

🤖 Generated with [Claude Code](https://claude.ai/code)